### PR TITLE
Add clarification of default TIME behavior

### DIFF
--- a/ObjObsSAP.tex
+++ b/ObjObsSAP.tex
@@ -347,6 +347,15 @@ the service response like:
 }
 \end{itemize}
 
+If no \textbf{TIME} parameter is provided, a service \textbf{MAY} apply a default
+time range for which it can confidently provide valid results.
+A client \textbf{MAY} request observability data for a longer time range;
+however, a service \textbf{MAY} impose a maximum allowable future time
+range beyond which results are not returned.
+
+A service \textbf{SHOULD} only return results for which it has reasonable
+confidence in the validity of the computed observability.
+
 See \textit{Successful Response} section for more info about valid
 VOTable res\-pon\-ses.
 


### PR DESCRIPTION
Following the email discussions, a small section should be added clarifying the default behavior of the optional TIME parameter.

Given no TIME parameter provided, a service may define some default date in the future to provide records until, e.g. a week from now. A user may attempt to retrieve dates farther in the future by supplying a TIME parameter, but the service may decline to return results beyond a certain date/time.

A snippet clarifying the rationale, that a service should only return results they are confident in the calculation of, has also been added.